### PR TITLE
Align jboss-logging dependency with jbossas/wildfly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
 
         <dependency>
             <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-spi</artifactId>
-            <version>2.1.2.GA</version>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.2.1.Final</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
Propose to change the dependency:

```
    <dependency>
        <groupId>org.jboss.logging</groupId>
        <artifactId>jboss-logging-spi</artifactId>
        <version>2.1.2.GA</version>
        <scope>compile</scope>
    </dependency>
```

to:

```
    <dependency>
        <groupId>org.jboss.logging</groupId>
        <artifactId>jboss-logging</artifactId>
        <version>3.2.1.Final</version>
        <scope>compile</scope>
    </dependency>
```

, because wildfly depends on _jboss-logging_ instead of _jboss-logging-spi_, and I think _jboss-logging-spi_ should be considered deprecated?
