### PR TITLE
Fix JBossEntityResolverUnitTestCase

### DIFF
--- a/src/test/java/org/jboss/test/util/test/xml/resolver/JBossEntityResolverUnitTestCase.java
+++ b/src/test/java/org/jboss/test/util/test/xml/resolver/JBossEntityResolverUnitTestCase.java
@@ -91,7 +91,7 @@ public class JBossEntityResolverUnitTestCase
       InputStream resolvedStream = resolvedSource.getByteStream();
       assertNotNull(resolvedStream);
       int resolvedSize = bytesTotal(resolvedStream);
-      assertEquals(333, resolvedSize);
+      assertEquals(324, resolvedSize);
    }
 
    public void testEmptyFilenameResolution()


### PR DESCRIPTION
The file: `src/test/resources/tst-config_5.xsd` contains 324 bytes instead of 333 bytes, see:

<pre>
lgao /sources/jboss-common-core $ cat src/test/resources/tst-config_5.xsd|wc -c
324
</pre>
